### PR TITLE
Running unit tests in Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ matrix:
       script:
         - mkdir build
         - cd build
-        - cmake -DCMAKE_CXX_COMPILER=g++-5 .. && make
+        - cmake -DCMAKE_CXX_COMPILER=g++-5 .. && make && ./runTests
     - os: osx
       osx_image: xcode7.3
       script:
         - mkdir build
         - cd build
-        - cmake .. && make
+        - cmake .. && make && ./runTests


### PR DESCRIPTION
So far, the CI builds have only run the build, not the unit tests. Fixed.