### PR TITLE
Bug fix for segfault in fixStaticSegmentRules

### DIFF
--- a/src/animation/staticSegments.cpp
+++ b/src/animation/staticSegments.cpp
@@ -141,7 +141,11 @@ ContinuousTimeline<ShapeRule> fixStaticSegmentRules(const ContinuousTimeline<Sha
 
 	// Find best solution. Start with a single replacement, then increase as necessary.
 	RuleChangeScenario bestScenario(shapeRules, {}, animate);
-	for (int replacementCount = 1; bestScenario.getStaticSegmentCount() > 0 && replacementCount <= maxReplacementCount; ++replacementCount) {
+	for (
+            int replacementCount = 1;
+            bestScenario.getStaticSegmentCount() > 0 && replacementCount <= std::min(static_cast<int>(possibleRuleChanges.size()), maxReplacementCount);
+            ++replacementCount
+        ) {
 		// Only the first <replacementCount> elements of `currentRuleChanges` count
 		auto currentRuleChanges(possibleRuleChanges);
 		do {


### PR DESCRIPTION
fixStaticSegmentRules could cause a segfault when trying to access out of the range of the currentRuleChanges iterator, if the size of possibleRuleChanges was less than 3 (maxReplacementCount).

The case exhibiting the problem had music in the input wav file, which has characteristics different from speech, which resulted in an unexpectedly low number of possibleRuleChanges in a static segment.