### PR TITLE
Fix build error resulting from assigning boost::uuids::random_generator

### DIFF
--- a/rhubarb/src/tools/platformTools.cpp
+++ b/rhubarb/src/tools/platformTools.cpp
@@ -57,7 +57,8 @@ path getBinDirectory() {
 
 path getTempFilePath() {
 	path tempDirectory = boost::filesystem::temp_directory_path();
-	string fileName = to_string(boost::uuids::random_generator()());
+	static boost::uuids::random_generator generateUuid;
+        string fileName = to_string(generateUuid());
 	return tempDirectory / fileName;
 }
 

--- a/rhubarb/src/tools/platformTools.cpp
+++ b/rhubarb/src/tools/platformTools.cpp
@@ -57,8 +57,7 @@ path getBinDirectory() {
 
 path getTempFilePath() {
 	path tempDirectory = boost::filesystem::temp_directory_path();
-	static auto generateUuid = boost::uuids::random_generator();
-	string fileName = to_string(generateUuid());
+	string fileName = to_string(boost::uuids::random_generator()());
 	return tempDirectory / fileName;
 }
 

--- a/rhubarb/src/tools/platformTools.cpp
+++ b/rhubarb/src/tools/platformTools.cpp
@@ -58,7 +58,7 @@ path getBinDirectory() {
 path getTempFilePath() {
 	path tempDirectory = boost::filesystem::temp_directory_path();
 	static boost::uuids::random_generator generateUuid;
-        string fileName = to_string(generateUuid());
+	string fileName = to_string(generateUuid());
 	return tempDirectory / fileName;
 }
 


### PR DESCRIPTION
Hi, I had trouble building rhubarb on linux using boost 1.67.0
```
[ 71%] Building CXX object CMakeFiles/rhubarb-tools.dir/src/tools/platformTools.cpp.o                                        
/home/rhubarb_user/Docs/...../rhubarb-lip-sync/rhubarb/src/tools/platformTools.cpp: In function ‘boost::filesyst
em::path getTempFilePath()’:                                                                                                 
/home/rhubarb_user/Docs/...../rhubarb-lip-sync/rhubarb/src/tools/platformTools.cpp:60:60: error: use of deleted 
function ‘boost::uuids::random_generator_pure::random_generator_pure(boost::uuids::random_generator_pure&&)’                 
  static auto generateUuid = boost::uuids::random_generator();                                                               
                                                            ^                                                                
In file included from /usr/include/boost/uuid/uuid_generators.hpp:17,                                                        
                 from /home/rhubarb_user/Docs/...../rhubarb-lip-sync/rhubarb/src/tools/platformTools.cpp:5:     
/usr/include/boost/uuid/random_generator.hpp:149:7: note: ‘boost::uuids::random_generator_pure::random_generator_pure(boost::
uuids::random_generator_pure&&)’ is implicitly deleted because the default definition would be ill-formed:                   
 class random_generator_pure                                                                                                 
       ^~~~~~~~~~~~~~~~~~~~~                                                                                                 
/usr/include/boost/uuid/random_generator.hpp:149:7: error: use of deleted function ‘boost::uuids::detail::random_provider::ra
ndom_provider(boost::uuids::detail::random_provider&&)’                                                                      
In file included from /usr/include/boost/uuid/random_generator.hpp:20,                                                       
                 from /usr/include/boost/uuid/uuid_generators.hpp:17,                                            
                 from /home/rhubarb_user/Docs/...../rhubarb-lip-sync/rhubarb/src/tools/platformTools.cpp:5:
/usr/include/boost/uuid/detail/random_provider.hpp:41:7: note: ‘boost::uuids::detail::random_provider::random_provider(boost$
:uuids::detail::random_provider&&)’ is implicitly deleted because the default definition would be ill-formed:               
 class random_provider                                                                                                      
       ^~~~~~~~~~~~~~~                                                                                          
/usr/include/boost/uuid/detail/random_provider.hpp:41:7: error: use of deleted function ‘boost::noncopyable_::noncopyable::n$ncopyable(const boost::noncopyable_::noncopyable&)’                                                             
In file included from /usr/include/boost/noncopyable.hpp:15,                                                                
                 from /usr/include/boost/system/error_code.hpp:18,                                                         
                 from /usr/include/boost/filesystem/path_traits.hpp:23,                                                    
                 from /usr/include/boost/filesystem/path.hpp:25,                                                            
                 from /usr/include/boost/filesystem/operations.hpp:25,                                             
                 from /home/rhubarb_user/Docs/...../rhubarb-lip-sync/rhubarb/src/tools/platformTools.cpp:1:
/usr/include/boost/core/noncopyable.hpp:34:7: note: declared here                                                
       noncopyable( const noncopyable& ) = delete;                                                                          
       ^~~~~~~~~~~                                                                                             
make[2]: *** [CMakeFiles/rhubarb-tools.dir/build.make:89: CMakeFiles/rhubarb-tools.dir/src/tools/platformTools.cpp.o] Error $
make[1]: *** [CMakeFiles/Makefile2:651: CMakeFiles/rhubarb-tools.dir/all] Error 2                                        
make: *** [Makefile:130: all] Error 2
```
This fixes the issue for me. What do you think?