### PR TITLE
Add support for 32bit PCM WAV files

### DIFF
--- a/rhubarb/src/audio/WaveFileReader.cpp
+++ b/rhubarb/src/audio/WaveFileReader.cpp
@@ -4,7 +4,6 @@
 #include <iostream>
 #include "tools/platformTools.h"
 #include "tools/fileTools.h"
-#include <climits>
 
 using std::runtime_error;
 using fmt::format;
@@ -179,7 +178,7 @@ inline AudioClip::value_type readSample(
 			case SampleFormat::Int32:
 			{
 				int raw = read<int>(file);
-				sum += toNormalizedFloat(raw, INT_MIN, INT_MAX);
+				sum += toNormalizedFloat(raw, INT32_MIN, INT32_MAX);
 				break;
 			}
 			case SampleFormat::Float32:

--- a/rhubarb/src/audio/WaveFileReader.h
+++ b/rhubarb/src/audio/WaveFileReader.h
@@ -7,6 +7,7 @@ enum class SampleFormat {
 	UInt8,
 	Int16,
 	Int24,
+	Int32,
 	Float32
 };
 


### PR DESCRIPTION
I have been working with rhubarb and run into 32bit PCM WAV files more often than not but they are not currently supported.

This will add support for reading 32bit PCM WAV files.